### PR TITLE
Refreshed document state when component destroyed

### DIFF
--- a/src/vue-document.js
+++ b/src/vue-document.js
@@ -106,6 +106,13 @@ export default function VueDocument (Vue, o) {
         this.$root[cache] = undefined
         injector.call(this, window.document)
       }
+    },
+    // not called on server-side
+    destroyed: function () {
+      if (this[prop]) {
+        this.$root[cache] = undefined
+        injector.call(this, window.document)
+      }
     }
   })
 }


### PR DESCRIPTION
This fixes an issue where the injector is not re-run under certain circumstances that it should be.

For example, consider that you have your top level Vue component set the title of the page to `My App`. I am using Vue Router and I click on a link that switches to a page that sets the page title to `Settings Page`. Vue Document successfully sets the title of the page to `Settings Page`. *But* when I go back to the previous page that should inherit the default value for the title, `My App`, the injector is *not* re-run because the root element is not remounted, because only its children have changed.

By running the injector on the destroyed event of the Vue components, the document title is updated even though the top level Vue component was not changed, and the value for the page title is properly inherited from the root Vue component.