### PR TITLE
Setup a default title for the title injector

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -149,6 +149,12 @@ vm.$documentForceUpdate(document)
 console.log(document.documentElement.outerHTML)
 ```
 
+### Caveats
+
+#### Setting Document Title when using a Router
+
+When using the title injector and a router like Vue Router, you have to set a default title for you app. This means applying the `document.head.title` property to your top level Vue element. If do not set a default title, when the user navigates to a page that does not specify a title, the title will be set to "Untitled".
+
 ## License
 
 [MIT](https://opensource.org/licenses/mit-license.php)

--- a/src/vue-document-injector-title.js
+++ b/src/vue-document-injector-title.js
@@ -17,6 +17,9 @@
  */
 export default function (document) {
   var metadata = this.$root.$document
-  var title = metadata.head && metadata.head.title
-  title != null && (document.title = title)
+  var title = 'Untitled'
+  if (metadata.head && metadata.head.title) {
+    title = metadata.head.title
+  }
+  document.title = title
 }


### PR DESCRIPTION
Title injector will set thepage title to "Untitled" if `document.head.title` is not set.

Added a note to the readme about needing a default title when using a router.

This also fixes a bug that occurs when the `document.head.title` goes from set to unset; the title would stop updating when the Vue components changed.